### PR TITLE
Fix PHP 8.1 issue: Passing null to parameter #1 ($string) of type string is deprecated #218

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea/
 vendor/
 composer.lock

--- a/lib/CrEOF/Geo/WKB/Parser.php
+++ b/lib/CrEOF/Geo/WKB/Parser.php
@@ -154,7 +154,12 @@ class Parser
             }
 
             $this->dimensions = $this->getDimensions($this->type);
-            $this->pointSize  = 2 + strlen($this->getDimensionType($this->dimensions));
+
+            if ($this->dimensions && $this->getDimensionType($this->dimensions)) {
+                $this->pointSize = 2 + strlen($this->getDimensionType($this->dimensions));
+            } else {
+                $this->pointSize = 2;
+            }
 
             $typeName = $this->getTypeName($this->type);
 


### PR DESCRIPTION
**Fix PHP 8.1 issue:**
- 500 [GET] Passing null to parameter 1 ($string) of type string is deprecated
- wkb-parser/lib/CrEOF/Geo/WKB/Parser.php [line:157]

https://php.watch/versions/8.1/internal-func-non-nullable-null-deprecation